### PR TITLE
Fixes issue with bash variable not expanding properly

### DIFF
--- a/linuxdeploy-plugin-conda.sh
+++ b/linuxdeploy-plugin-conda.sh
@@ -112,7 +112,7 @@ if [ "$PIP_REQUIREMENTS" != "" ]; then
     fi
 
     # add verbose flag if requested
-    pip install -U "$PIP_REQUIREMENTS" --prefix="$APPDIR"/usr/conda/ "${PIP_VERBOSE:+-v}"
+    pip install -U $PIP_REQUIREMENTS --prefix="$APPDIR"/usr/conda/ ${PIP_VERBOSE:+-v}
 
 
     if [ "$PIP_WORKDIR" != "" ]; then

--- a/linuxdeploy-plugin-conda.sh
+++ b/linuxdeploy-plugin-conda.sh
@@ -111,12 +111,9 @@ if [ "$PIP_REQUIREMENTS" != "" ]; then
         pushd "$PIP_WORKDIR"
     fi
 
-    pip_args=('--prefix="$APPDIR"/usr/conda/')
-    if [ "$PIP_VERBOSE" != "" ]; then
-        pip_args+=("-v")
-    fi
+    # add verbose flag if requested
+    pip install -U "$PIP_REQUIREMENTS" --prefix="$APPDIR"/usr/conda/ "${PIP_VERBOSE:+-v}"
 
-    pip install -U $PIP_REQUIREMENTS "${pip_args[@]}"
 
     if [ "$PIP_WORKDIR" != "" ]; then
         popd


### PR DESCRIPTION
Variable expansion happens only once and isn't recursive resulting in pip installing the package into a wrong directory