### PR TITLE
Fix missing ln -r flag in Centos 6

### DIFF
--- a/linuxdeploy-plugin-conda.sh
+++ b/linuxdeploy-plugin-conda.sh
@@ -126,9 +126,12 @@ fi
 
 # create symlinks for all binaries in usr/conda/bin/ in usr/bin/
 mkdir -p "$APPDIR"/usr/bin/
-for i in "$APPDIR"/usr/conda/bin/*; do
-    ln -s -r "$i" "$APPDIR"/usr/bin/
+pushd "$APPDIR"
+for i in usr/conda/bin/*; do
+    ln -s ../../"$i" usr/bin/
 done
+popd
+
 
 # remove bloat
 pushd "$APPDIR"/usr/conda


### PR DESCRIPTION
The ln version included in Centos 6 doesn't have the '-r' flag which makes links relative. Therefore we workaround this issue by steeping in the AppDir folder and generating links from there.

fix #28