### PR TITLE
Do not remove distutils during cleanup

### DIFF
--- a/linuxdeploy-plugin-conda.sh
+++ b/linuxdeploy-plugin-conda.sh
@@ -144,5 +144,4 @@ rm -rf include/
 rm -rf share/{gtk-,}doc
 rm -rf share/man
 rm -rf lib/python?.?/site-packages/{setuptools,pip}
-rm -rf lib/python?.?/distutils
 popd


### PR DESCRIPTION
Some packages might still depend on the functionality provided by distutils. For example matplotlib(~3.1) needs distutils during runtime, otherwise it fails with an ImportError.

Code where distutils is being used:
https://github.com/matplotlib/matplotlib/blob/406cce64a6fbc9cbbd06e62116bcebb1beaaa3f9/lib/matplotlib/backends/qt_compat.py#L14